### PR TITLE
Add missing NDK units and JIP build file

### DIFF
--- a/src/PascalDevelop/PascalDevelop.jip
+++ b/src/PascalDevelop/PascalDevelop.jip
@@ -1,0 +1,1 @@
+{"stName":"PascalDevelop","stLibsDir":"","bUseTimeLog":false,"stDexlibsDir":"","stExcludeDirs":"","stMainJava":"src\/com\/assoft\/PascalDevelop\/MainActivity.java","stAPK":"","stAssetsDir":"res\/","stAndroidJarPath":"android-api10.jar"}


### PR DESCRIPTION
I found that I missed building the NDK GL and bitmap units. So I've added them.

I also was able to get the JavaIDEdroid v2.7.0 with Pro key to build this project by copying the "kn" folder into the "PascalDevelop/src" folder and using the newly added PascalDevelop.jip. This uses the bsh scripts built into the JavaIDEdroid app. I'm not sure if the resultant package works yet. But will test shortly. I imagine you'd rather see it build from DroidDevelop... but that requires JavaIDEdroid anyways, so this was the perceived path of least resistance. I want to start overhauling things!
